### PR TITLE
Fixed crash in iOS 11 when adding a subview directly in visualEffectView

### DIFF
--- a/Pod/Classes/GKFadeNavigationController.m
+++ b/Pod/Classes/GKFadeNavigationController.m
@@ -135,7 +135,7 @@
         shadowView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2f];
         shadowView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 
-        [self.visualEffectView addSubview:shadowView];
+        [_visualEffectView.contentView addSubview:shadowView];
     }
     
     return _visualEffectView;


### PR DESCRIPTION
Fixed crash in iOS 11 when adding a subview in directly visualEffectView instead of it's contentView.

Fixes gklka/GKFadeNavigationController#6